### PR TITLE
v2.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [10, 12, 13]
+        node: [10, 12, 14]
     # must use Linux for redis container
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pub-src-redis
-![CI](https://github.com/jldec/pub-src-redis/workflows/CI/badge.svg)
+[![CI](https://github.com/jldec/pub-src-redis/workflows/CI/badge.svg)](https://github.com/jldec/pub-src-redis/actions)
 
 redis source for pub-server and pub-generator - also provides cache for other sources
 
@@ -48,7 +48,7 @@ export RCP={port}
 
 ### source.cache(src, [cacheOpts])
 
-- interposes `src.get()` and `src.put()`, and also adds `src.flush()`
+- interposes `src.get()` and `src.put()`, for a different source (src) like github.
 
 - `src.get()` will read from src on the first call, and subsequently read only from redis,
   unless the option `get({fromSource:true}, cb)` is used
@@ -56,7 +56,9 @@ export RCP={port}
 - `src.put()` will write directly to redis.
    `cacheOpts.writeThru` means that `put()` will also write to src before returning
 
-- `src.flush()` writes ALL files from cache back to source - it does not remember which ones were written.
+- `src.commit()` writes a single file from cache back to source - only available if `!cacheOpts.writeThru`.
+
+- `src.revert()` reverts a single file from source - only available if `!cacheOpts.writeThru`.
 
 ### source.clear(cb)
 - redis-specific api - used mainly for testing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pub-src-redis",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "description": "redis source for pub-server and pub-generator - also provides cache for other sources",
   "main": "pub-src-redis.js",
   "dependencies": {
@@ -10,7 +10,7 @@
     "redis": "^3.0.2"
   },
   "devDependencies": {
-    "eslint": "^7.1.0",
+    "eslint": "^7.2.0",
     "tape": "^5.0.1"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "pub-src-redis.js",
   "dependencies": {
     "debug": "^4.1.1",
-    "pub-src-fs": "^2.1.0",
-    "pub-util": "^3.1.0",
+    "pub-src-fs": "^2.1.1",
+    "pub-util": "^3.1.1",
     "redis": "^3.0.2"
   },
   "devDependencies": {
-    "eslint": "^7.2.0",
+    "eslint": "^7.5.0",
     "tape": "^5.0.1"
   },
   "files": [

--- a/pub-src-redis.js
+++ b/pub-src-redis.js
@@ -56,6 +56,7 @@ module.exports = function sourceRedis(sourceOpts) {
       redis = redisLib.createClient(port, host, redisOpts); }
   }
 
+  // get all files, or if options.stage, get files with `stage` flag.
   function get(options, cb) {
     if (typeof options === 'function') { cb = options; options = {}; }
     connect();
@@ -75,10 +76,12 @@ module.exports = function sourceRedis(sourceOpts) {
 
       // turn single hash object into properly sorted files array
       try {
-        var files = u.map(data, function(json, path) {
+        var files = [];
+
+        u.each(data, function(json, path) {
           var data = JSON.parse(json);
-          var file = { path:path, text:data.text };
-          return file;
+          if (options.stage && !data.stage) return;
+          files.push({ path:path, text:data.text });
         });
 
         files = u.sortBy(files, function(entry) {
@@ -96,6 +99,7 @@ module.exports = function sourceRedis(sourceOpts) {
     });
   }
 
+  // put files - if options.stage, put with `stage` flag.
   function put(files, options, cb) {
     if (typeof options === 'function') { cb = options; options = {}; }
     if (!sourceOpts.writable) return cb(new Error('cannot write to non-writable source'));

--- a/test/test-non-file.js
+++ b/test/test-non-file.js
@@ -18,7 +18,7 @@ test('put-get non-file data', { timeout:2000 }, function(t) {
 
   var sourceRedis = require('..')( { path:'test-non-file', type:'JSON', writable:1 } );
 
-  sourceRedis.put(data, null, function(err) {
+  sourceRedis.put(data, function(err) {
     t.error(err);
 
     sourceRedis.get(function(err, redisData) {

--- a/test/test-organic.js
+++ b/test/test-organic.js
@@ -20,7 +20,7 @@ test('read write node-modules *.js', { timeout:5000 }, function(t) {
     sourceFs.get(function(err, filesFs) {
       t.error(err);
 
-      sourceRedis.put(filesFs, null, function(err) {
+      sourceRedis.put(filesFs, function(err) {
         t.error(err);
 
         sourceRedis.get(function(err, filesRedis) {

--- a/test/test-sort.js
+++ b/test/test-sort.js
@@ -46,7 +46,7 @@ test('compare sorted file lists', { timeout:500 }, function(t) {
       // console.log(filesFs);
       t.deepEqual(filesFs, expected);
 
-      sourceRedis.put(filesFs.reverse(), null, function(err) {
+      sourceRedis.put(filesFs.reverse(), function(err) {
         t.error(err);
 
         sourceRedis.get(function(err, filesRedis) {

--- a/test/test-tree.js
+++ b/test/test-tree.js
@@ -38,7 +38,7 @@ test('flush-put-get', { timeout:500 }, function(t) {
       // console.log(filesFs);
       t.deepEqual(filesFs, expected);
 
-      sourceRedis.put(filesFs.reverse(), null, function(err) {
+      sourceRedis.put(filesFs.reverse(), function(err) {
         t.error(err);
 
         sourceRedis.get(function(err, filesRedis) {
@@ -84,7 +84,7 @@ test('flush-put-put-etc.-get', { timeout:500 }, function(t) {
       });
 
       u.each(filesFs, function(file) {
-        sourceRedis.put([file], null, function(err) {
+        sourceRedis.put([file], function(err) {
           t.error(err);
 
           getAndTest();


### PR DESCRIPTION
- changes internal representation of cached files to use JSON (upgrade should happen automatically)  
- introduces two-level cache behavior - cache2 is !writeThru for staging, cache is writeThru like before
- single file commit() writes from cache2 to cache to source
- single file revert() replaces staged file in cache2 with original from cache
- see pub-resolve-opts for auto-configuration
- bumped deps
- test on node 14
- fixed ci-badge link